### PR TITLE
Switch off request logging.

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -25,4 +25,4 @@ echo "### generated config ###"
 cat ./nginx.conf
 
 cp ./nginx.conf /etc/nginx/nginx.conf
-nginx -g "daemon off; error_log /dev/stderr notice;"
+nginx -g "daemon off; access_log off;"


### PR DESCRIPTION
Turn off request logging. 
Error log is already redirected to stderr in base nginx image, so I removed the error_log configuration.